### PR TITLE
libstagefright: Allow HFR-60 in HAL-3 recording

### DIFF
--- a/media/libstagefright/bqhelper/GraphicBufferSource.cpp
+++ b/media/libstagefright/bqhelper/GraphicBufferSource.cpp
@@ -753,7 +753,7 @@ bool GraphicBufferSource::calculateCodecTimestamp_l(
 
     if (mCaptureFps > 0.
             && (mFps > 2 * mCaptureFps
-            || mCaptureFps > 2 * mFps)) {
+            || mCaptureFps > mFps)) {
         // Time lapse or slow motion mode
         if (mPrevCaptureUs < 0ll) {
             // first capture


### PR DESCRIPTION
Time stamp manipulation is needed to support HFR-60
since timePerFrame and timePerCapture are different.
Made changes for the same.

Change-Id: I92521b899cb82e5fa868f2628afc0b10d6f8bf80
CRs-Fixed: 2105921
Signed-off-by: DennySPB <dennyspb@gmail.com>