### PR TITLE
libcameraservice: Add support for miui camera mode

### DIFF
--- a/services/camera/libcameraservice/CameraService.cpp
+++ b/services/camera/libcameraservice/CameraService.cpp
@@ -35,6 +35,7 @@
 
 #include <android-base/macros.h>
 #include <android-base/parseint.h>
+#include <android-base/properties.h>
 #include <android-base/stringprintf.h>
 #include <binder/ActivityManager.h>
 #include <binder/AppOpsManager.h>
@@ -85,6 +86,7 @@ namespace {
 namespace android {
 
 using base::StringPrintf;
+using base::SetProperty;
 using binder::Status;
 using namespace camera3;
 using frameworks::cameraservice::service::V2_0::implementation::HidlCameraService;
@@ -3498,6 +3500,15 @@ status_t CameraService::BasicClient::startCameraOps() {
     }
 
     mOpsActive = true;
+
+    // Configure miui camera mode
+    if (strcmp(String8(mClientPackageName).string(), "com.android.camera") == 0) {
+        SetProperty("sys.camera.miui.apk", "1");
+        ALOGI("Enabling miui camera mode");
+    } else {
+        SetProperty("sys.camera.miui.apk", "0");
+        ALOGI("Disabling miui camera mode");
+    }
 
     // Transition device availability listeners from PRESENT -> NOT_AVAILABLE
     sCameraService->updateStatus(StatusInternal::NOT_AVAILABLE, mCameraIdStr);


### PR DESCRIPTION
 * devices like ginkgo and some xiaomi sdm660 use miui camera mode in camera hal to activate certain functions in camera hal, these are enabled when vendor.camera.miui.apk is set to 1 based on sys.camera.miui.apk value

 * if this prop is set by default gcam crashes, so we must do it dynamically

 * xiaomi does this in stock libcameraservice but unfortunately we don't have stock android 12 to use prebuilt lib

Change-Id: I8d9ee4e650f3e2196546570c183c9d169b8aa335